### PR TITLE
Debug FormState `_activated` logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "formstate-x",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formstate-x",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Extended alternative for formstate",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Maintain its own `_validated` in `FormState`, so it can be activated even with no fields.