### PR TITLE
Debug `disableValidationWhen`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "formstate-x",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formstate-x",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Extended alternative for formstate",
   "repository": {
     "type": "git",

--- a/src/formState.spec.ts
+++ b/src/formState.spec.ts
@@ -856,7 +856,7 @@ describe('FormState (mode: array) validation', () => {
     state.dispose()
   })
 
-  it('should work well with disableValidationWhen', async () => {
+  fit('should work well with disableValidationWhen', async () => {
     const options = observable({ disabled: false })
     const notEmpty = (value: string) => value === '' && 'empty'
     const initialValue = ['123', '456']
@@ -871,16 +871,19 @@ describe('FormState (mode: array) validation', () => {
     runInAction(() => options.disabled = true)
 
     await state.validate()
+    expect(state.$[0].hasError).toBe(false)
     expect(state.hasError).toBe(false)
     expect(state.error).toBeUndefined()
 
     state.$[0].onChange('')
     await state.validate()
+    expect(state.$[0].hasError).toBe(false)
     expect(state.hasError).toBe(false)
     expect(state.error).toBeUndefined()
 
     runInAction(() => options.disabled = false)
     await delay()
+    expect(state.$[0].hasError).toBe(true)
     expect(state.hasError).toBe(true)
     expect(state.error).toBe('empty')
 

--- a/src/formState.spec.ts
+++ b/src/formState.spec.ts
@@ -856,7 +856,7 @@ describe('FormState (mode: array) validation', () => {
     state.dispose()
   })
 
-  fit('should work well with disableValidationWhen', async () => {
+  it('should work well with disableValidationWhen', async () => {
     const options = observable({ disabled: false })
     const notEmpty = (value: string) => value === '' && 'empty'
     const initialValue = ['123', '456']

--- a/src/formState.ts
+++ b/src/formState.ts
@@ -239,6 +239,9 @@ export default class FormState<TFields extends ValidatableFields, TValue = Value
    */
   @action disableValidationWhen(predict: () => boolean) {
     this.shouldDisableValidation = predict
+    this.fields.forEach(
+      field => field.disableValidationWhen(predict)
+    )
     return this
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,7 @@ export interface ComposibleValidatable<T, TValue = T> extends Validatable<T, TVa
   dirty: boolean
   _activated: boolean
   _validateStatus: ValidateStatus
+  disableValidationWhen: (predict: () => boolean) => this
 }
 
 /** Function to do dispose. */


### PR DESCRIPTION
* 在给 `FormState` 实例配置 `disableValidationWhen` 时，使用相同的 `predict` 对其 fields 进行配置