### PR TITLE
Revert `disableValidationWhen` behavior of `FormState`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "formstate-x",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formstate-x",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Extended alternative for formstate",
   "repository": {
     "type": "git",

--- a/src/formState.spec.ts
+++ b/src/formState.spec.ts
@@ -871,19 +871,16 @@ describe('FormState (mode: array) validation', () => {
     runInAction(() => options.disabled = true)
 
     await state.validate()
-    expect(state.$[0].hasError).toBe(false)
     expect(state.hasError).toBe(false)
     expect(state.error).toBeUndefined()
 
     state.$[0].onChange('')
     await state.validate()
-    expect(state.$[0].hasError).toBe(false)
     expect(state.hasError).toBe(false)
     expect(state.error).toBeUndefined()
 
     runInAction(() => options.disabled = false)
     await delay()
-    expect(state.$[0].hasError).toBe(true)
     expect(state.hasError).toBe(true)
     expect(state.error).toBe('empty')
 

--- a/src/formState.ts
+++ b/src/formState.ts
@@ -239,9 +239,6 @@ export default class FormState<TFields extends ValidatableFields, TValue = Value
    */
   @action disableValidationWhen(predict: () => boolean) {
     this.shouldDisableValidation = predict
-    this.fields.forEach(
-      field => field.disableValidationWhen(predict)
-    )
     return this
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,7 +49,6 @@ export interface ComposibleValidatable<T, TValue = T> extends Validatable<T, TVa
   dirty: boolean
   _activated: boolean
   _validateStatus: ValidateStatus
-  disableValidationWhen: (predict: () => boolean) => this
 }
 
 /** Function to do dispose. */


### PR DESCRIPTION
如 #8 中 [所讨论的](https://github.com/qiniu/formstate-x/pull/8#discussion_r347988959) ，“在给 FormState 实例配置 `disableValidationWhen` 时，使用相同的 predict 对其 fields 进行配置”的方案并不能解决原先的问题，可能会引入新的使用问题

这里先 revert 改动，该问题的解决姿势（以及是不是需要解决）后续再讨论