### PR TITLE
修复携带相同值的 `onChange` 触发后不能正确 validate 的 bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "formstate-x",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formstate-x",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Extended alternative for formstate",
   "repository": {
     "type": "git",

--- a/src/fieldState.spec.ts
+++ b/src/fieldState.spec.ts
@@ -158,6 +158,22 @@ describe('FieldState validation', () => {
     state.dispose()
   })
 
+  it('should work well with onChange of same value', async () => {
+    const state = createFieldState(1).validators(
+      () => null
+    )
+    await state.validate()
+    expect(state.validated).toBe(true)
+    expect(state.validating).toBe(false)
+    expect(state.hasError).toBe(false)
+
+    state.onChange(1)
+    await delay()
+    expect(state.validated).toBe(true)
+    expect(state.validating).toBe(false)
+    expect(state.hasError).toBe(false)
+  })
+
   it('should work well with validate()', async () => {
     const state = createFieldState('').validators(val => !val && 'empty')
     state.validate()

--- a/src/fieldState.ts
+++ b/src/fieldState.ts
@@ -117,7 +117,9 @@ export default class FieldState<TValue> extends Disposable implements Composible
    * Set `_value` on change event.
    */
   @action onChange(value: TValue) {
-    this.setValue(value)
+    if (value !== this._value) {
+      this.setValue(value)
+    }
   }
 
   /**


### PR DESCRIPTION
`onChange` 会触发 `setValue`，设置 `validateStatus`，但不会触发 `_validate`（`_value` 值未变更，虽 setter 被调用，不触发 `autorun`）