### PR TITLE
debug debounce of `FieldState`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formstate-x",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Extended alternative for formstate",
   "repository": {
     "type": "git",

--- a/src/fieldState.spec.ts
+++ b/src/fieldState.spec.ts
@@ -375,4 +375,29 @@ describe('FieldState validation', () => {
 
     state.dispose()
   })
+
+  it('should work well with delay', async () => {
+    const state = new FieldState('0', 1000)
+
+    state.onChange('1')
+    expect(state.value).toBe('0')
+    await delay(250)
+    expect(state.value).toBe('0')
+
+    state.onChange('2')
+    expect(state.value).toBe('0')
+    await delay(500)
+    expect(state.value).toBe('0')
+
+    state.onChange('3')
+    expect(state.value).toBe('0')
+    await delay(750)
+    expect(state.value).toBe('0')
+
+    state.onChange('4')
+    expect(state.value).toBe('0')
+    await delay(1250)
+    expect(state.value).toBe('4')
+
+  })
 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -55,3 +55,13 @@ export function applyValidators<TValue>(value: TValue, validators: Validator<TVa
 
   return asyncResponsesAnd(asyncResponses)
 }
+
+export function debounce(fn: () => void, delay: number) {
+  let timeout: any = null
+  return () => {
+    if (timeout) {
+      clearTimeout(timeout)
+    }
+    timeout = setTimeout(fn, delay)
+  }
+}


### PR DESCRIPTION
先前依赖 MobX `reaction` 的 `options.delay` 实现 `_value` 到 `value` 同步的 debounce，发现这个靠不住，见 https://github.com/mobxjs/mobx/issues/1956

这里改为使用自己实现的 `debounce`