### PR TITLE
Fix typedoc config

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,5 @@
 {
-  "packages": ".",
+  "entryPoints": ["./src/index.ts", "./src/adapter/index.ts"],
   "out": "docs",
   "exclude": "src/utils.ts",
   "excludePrivate": true,


### PR DESCRIPTION
Use `entryPoints` instead of `package` for typedoc configuration. The latter does not work in Github Action.