### PR TITLE
Optimize `ValueOf`

### DIFF
--- a/src/types.spec.ts
+++ b/src/types.spec.ts
@@ -1,0 +1,18 @@
+import { Validatable, ValueOf } from './types'
+
+// https://stackoverflow.com/questions/68961864/how-does-the-equals-work-in-typescript/68963796#68963796
+export type Equal<X, Y> = (
+  (<T>() => T extends X ? 1 : 2) extends
+  (<T>() => T extends Y ? 1 : 2)
+  ? true
+  : false
+)
+
+function assertEqual<T, S>(..._args: Equal<T, S> extends true ? [] : [never]) {}
+
+describe('ValueOf', () => {
+  it('should work well with Validatable', () => {
+    const a = {} as Validatable<string>
+    assertEqual<ValueOf<typeof a>, string>()
+  })
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,7 +92,15 @@ export type ValueOfFields<Fields> = (
 export type ValueOf<State> = (
   State extends FormState<infer Fields>
   ? ValueOfFields<Fields>
-  : ValueOfFieldState<State>
+  : (
+    State extends FieldState<infer V>
+    ? V
+    : (
+      State extends Validatable<unknown, infer V>
+      ? V
+      : never
+    )
+  )
 )
 
 /** Validate status. */


### PR DESCRIPTION
So that `ValueOf` supports any state (other than `FieldState` & `FormState`) which correctly implemented `Validatable`.

For code:

```ts
const fooState: Validatable<string> = ...

const formState = new FormState({
  foo: fooState
})

typeof fooState.value.foo // expected to be `string`
```

Without this PR, `typeof fooState.value.foo` will be derived as `never`.

With this PR, it will be derived as `string` as expected


