### PR TITLE
Details for `dirty` & `DebouncedState`

### DIFF
--- a/src/adapter/v2.spec.ts
+++ b/src/adapter/v2.spec.ts
@@ -13,7 +13,7 @@ describe('fromV2', () => {
       const state = fromV2(stateV2)
 
       expect(state.value).toBe('')
-      expect(state.dirty).toBe(false)
+      expect(state.touched).toBe(false)
       expect(state.activated).toBe(false)
       expect<typeof stateV2>(state.$).toBe(stateV2)
     })
@@ -25,7 +25,7 @@ describe('fromV2', () => {
       stateV2.onChange('foo')
 
       await delay()
-      expect(state.dirty).toBe(true)
+      expect(state.touched).toBe(true)
       expect(state.value).toBe('foo')
       expect(state.activated).toBe(true)
 
@@ -35,7 +35,7 @@ describe('fromV2', () => {
       expect(stateV2._value).toBe('bar')
       expect(stateV2.value).toBe('bar')
       expect(stateV2.$).toBe('bar')
-      expect(state.dirty).toBe(true)
+      expect(state.touched).toBe(true)
       expect(state.value).toBe('bar')
     })
 
@@ -44,7 +44,7 @@ describe('fromV2', () => {
       const state = fromV2(stateV2)
 
       stateV2.set('foo')
-      expect(state.dirty).toBe(true)
+      expect(state.touched).toBe(true)
       expect(state.value).toBe('foo')
       expect(state.activated).toBe(false)
 
@@ -52,7 +52,7 @@ describe('fromV2', () => {
       expect(stateV2.dirty).toBe(true)
       expect(stateV2._value).toBe('bar')
       expect(stateV2.value).toBe('bar')
-      expect(state.dirty).toBe(true)
+      expect(state.touched).toBe(true)
       expect(state.value).toBe('bar')
       expect(state.activated).toBe(false)
     })
@@ -69,7 +69,7 @@ describe('fromV2', () => {
       expect(stateV2.value).toBe(initialValue)
       expect(stateV2.dirty).toBe(false)
       expect(state.value).toBe(initialValue)
-      expect(state.dirty).toBe(false)
+      expect(state.touched).toBe(false)
       expect(state.activated).toBe(false)
 
       state.onChange('456')
@@ -78,7 +78,7 @@ describe('fromV2', () => {
       expect(stateV2.value).toBe(initialValue)
       expect(stateV2.dirty).toBe(false)
       expect(state.value).toBe(initialValue)
-      expect(state.dirty).toBe(false)
+      expect(state.touched).toBe(false)
       expect(state.activated).toBe(false)
 
       state.dispose()
@@ -182,7 +182,7 @@ describe('fromV2', () => {
       expect(stateV2._validateStatus).toBe(v2.ValidateStatus.NotValidated)
       expect(stateV2.error).toBe(undefined)
       expect(state.value).toBe(initialValue)
-      expect(state.dirty).toBe(false)
+      expect(state.touched).toBe(false)
       expect(state.validateStatus).toBe(v3.ValidateStatus.NotValidated)
       expect(state.error).toBe(undefined)
       expect(state.ownError).toBe(undefined)
@@ -241,7 +241,7 @@ describe('fromV2', () => {
       const state = fromV2(stateV2)
 
       expect(state.value).toEqual({ foo: '' })
-      expect(state.dirty).toBe(false)
+      expect(state.touched).toBe(false)
       expect(state.activated).toBe(false)
       expect<typeof stateV2>(state.$).toBe(stateV2)
     })
@@ -253,7 +253,7 @@ describe('fromV2', () => {
       state.onChange({ foo: 'foo' })
 
       await delay()
-      expect(state.dirty).toBe(true)
+      expect(state.touched).toBe(true)
       expect(state.value).toEqual({ foo: 'foo' })
       expect(state.activated).toBe(true)
 
@@ -264,7 +264,7 @@ describe('fromV2', () => {
       expect(stateV2.$.foo.value).toBe('bar')
       expect(stateV2.dirty).toBe(true)
       expect(stateV2.value).toEqual({ foo: 'bar' })
-      expect(state.dirty).toBe(true)
+      expect(state.touched).toBe(true)
       expect(state.value).toEqual({ foo: 'bar' })
       expect(state.activated).toBe(true)
     })
@@ -274,7 +274,7 @@ describe('fromV2', () => {
       const state = fromV2(stateV2)
 
       state.set({ foo: 'foo' })
-      expect(state.dirty).toBe(true)
+      expect(state.touched).toBe(true)
       expect(state.value).toEqual({ foo: 'foo' })
       expect(state.activated).toBe(false)
 
@@ -283,7 +283,7 @@ describe('fromV2', () => {
       expect(stateV2.$.foo.value).toBe('bar')
       expect(stateV2.dirty).toBe(true)
       expect(stateV2.value).toEqual({ foo: 'bar' })
-      expect(state.dirty).toBe(true)
+      expect(state.touched).toBe(true)
       expect(state.value).toEqual({ foo: 'bar' })
       expect(state.activated).toBe(false)
     })
@@ -299,7 +299,7 @@ describe('fromV2', () => {
       expect(stateV2.value).toEqual({ foo: '' })
       expect(stateV2.dirty).toBe(false)
       expect(state.value).toEqual({ foo: '' })
-      expect(state.dirty).toBe(false)
+      expect(state.touched).toBe(false)
       expect(state.activated).toBe(false)
 
       state.onChange({ foo: 'bar' })
@@ -308,7 +308,7 @@ describe('fromV2', () => {
       expect(stateV2.value).toEqual({ foo: '' })
       expect(stateV2.dirty).toBe(false)
       expect(state.value).toEqual({ foo: '' })
-      expect(state.dirty).toBe(false)
+      expect(state.touched).toBe(false)
       expect(state.activated).toBe(false)
 
       state.dispose()
@@ -414,7 +414,7 @@ describe('fromV2', () => {
       expect(stateV2._validateStatus).toBe(v2.ValidateStatus.NotValidated)
       expect(stateV2.error).toBe(undefined)
       expect(state.value).toEqual(initialValue)
-      expect(state.dirty).toBe(false)
+      expect(state.touched).toBe(false)
       expect(state.validateStatus).toBe(v3.ValidateStatus.NotValidated)
       expect(state.error).toBe(undefined)
       expect(state.ownError).toBe(undefined)
@@ -547,7 +547,7 @@ describe('toV2', () => {
       state.reset()
 
       expect<string>(stateV3.value).toBe('')
-      expect(stateV3.dirty).toBe(false)
+      expect(stateV3.touched).toBe(false)
       expect(state.value).toBe('')
       expect(state.dirty).toBe(false)
       expect(state._activated).toBe(false)
@@ -556,7 +556,7 @@ describe('toV2', () => {
       state.reset()
 
       expect(stateV3.value).toBe('')
-      expect(stateV3.dirty).toBe(false)
+      expect(stateV3.touched).toBe(false)
       expect(state.value).toBe('')
       expect(state.dirty).toBe(false)
       expect(state._activated).toBe(false)
@@ -702,7 +702,7 @@ describe('toV2', () => {
         this.value = initialValue
       }
       value: V
-      dirty = false
+      touched = false
       ownError = undefined
       error = undefined
       activated = false

--- a/src/adapter/v2.ts
+++ b/src/adapter/v2.ts
@@ -23,7 +23,7 @@ class Upgrader<T extends v2.ComposibleValidatable<unknown, V>, V> extends BaseSt
   @computed get $() { return this.stateV2 }
 
   @computed get value() { return this.stateV2.value }
-  @computed get dirty() { return this.stateV2.dirty }
+  @computed get touched() { return this.stateV2.dirty }
   @computed get ownError() {
     return getV3OwnError(this.stateV2)
   }
@@ -100,7 +100,7 @@ class Downgrader<T extends v3.IState<V>, V> extends Disposable implements IV2Sta
   validate() { return this.stateV3.validate() }
   reset() { this.stateV3.reset() }
 
-  @computed get dirty() { return this.stateV3.dirty }
+  @computed get dirty() { return this.stateV3.touched }
   @computed get _activated() { return this.stateV3.activated }
   @computed get _validateStatus() {
     return getV2ValidateStatus(this.stateV3)

--- a/src/debouncedState.spec.ts
+++ b/src/debouncedState.spec.ts
@@ -164,7 +164,7 @@ describe('DebouncedFieldState', () => {
 
     expect(state.$.value).toBe(initialValue)
     expect(state.value).toBe(initialValue)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(false)
   })
 
   it('should initialize well with default delay as 200ms', async () => {
@@ -173,7 +173,7 @@ describe('DebouncedFieldState', () => {
 
     expect(state.$.value).toBe(initialValue)
     expect(state.value).toBe(initialValue)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(false)
 
     const newValue = 'abc'
     state.onChange(newValue)
@@ -181,13 +181,13 @@ describe('DebouncedFieldState', () => {
 
     expect(state.$.value).toBe(newValue)
     expect(state.value).toBe(initialValue)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(false)
 
     await delay(100)
 
     expect(state.$.value).toBe(newValue)
     expect(state.value).toBe(newValue)
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
   })
 
   it('should onChange well', async () => {
@@ -202,14 +202,14 @@ describe('DebouncedFieldState', () => {
     expect(state.value).toBe(initialValue)
     expect(state.activated).toBe(false)
     expect(state.validateStatus).toBe(ValidateStatus.NotValidated)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(false)
 
     await delay()
     expect(state.$.value).toBe(value)
     expect(state.value).toBe(value)
     expect(state.activated).toBe(true)
     expect(state.validateStatus).toBe(ValidateStatus.Validated)
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
 
     const newValue = '789'
     state.$.onChange('456')
@@ -220,7 +220,7 @@ describe('DebouncedFieldState', () => {
     await delay()
     expect(state.$.value).toBe(newValue)
     expect(state.value).toBe(newValue)
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
 
     const invalidValue = '123456'
     state.$.onChange(invalidValue)
@@ -240,7 +240,7 @@ describe('DebouncedFieldState', () => {
     state.set(value)
     expect(state.$.value).toBe(value)
     expect(state.value).toBe(value)
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
 
     // set 不应该使 field 激活
     expect(state.validating).toBe(false)
@@ -255,7 +255,7 @@ describe('DebouncedFieldState', () => {
     await delay()
     expect(state.$.value).toBe(value)
     expect(state.value).toBe(value)
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
   })
 
   it('should reset well', async () => {
@@ -268,14 +268,14 @@ describe('DebouncedFieldState', () => {
 
     expect(state.$.value).toBe(initialValue)
     expect(state.value).toBe(initialValue)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(false)
 
     state.$.onChange('456')
     state.reset()
 
     expect(state.$.value).toBe(initialValue)
     expect(state.value).toBe(initialValue)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(false)
   })
 
   it('should work well with delay', async () => {
@@ -397,7 +397,7 @@ describe('DebouncedFieldState validation', () => {
     state.reset()
     expect(state.$.value).toBe(initialValue)
     expect(state.value).toBe(initialValue)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(false)
     expect(state.validating).toBe(false)
     expect(state.hasError).toBe(false)
     expect(state.error).toBeUndefined()

--- a/src/debouncedState.ts
+++ b/src/debouncedState.ts
@@ -19,12 +19,12 @@ export class DebouncedState<S extends IState<V>, V = ValueOf<S>> extends Validat
   public $: S
 
   @observable.ref private syncedValue!: V
-  @observable.ref private syncedDirty!: boolean
+  @observable.ref private syncedTouched!: boolean
   @observable.ref private syncedActivated!: boolean
 
   @action private sync() {
     this.syncedValue = this.$.value
-    this.syncedDirty = this.$.dirty
+    this.syncedTouched = this.$.touched
     this.syncedActivated = this.$.activated
   }
 
@@ -32,8 +32,8 @@ export class DebouncedState<S extends IState<V>, V = ValueOf<S>> extends Validat
     return this.syncedValue
   }
 
-  @computed get dirty() {
-    return this.syncedDirty
+  @computed get touched() {
+    return this.syncedTouched
   }
 
   @override override get ownError() {

--- a/src/fieldState.spec.ts
+++ b/src/fieldState.spec.ts
@@ -9,7 +9,7 @@ describe('FieldState', () => {
     const state = new FieldState(initialValue)
 
     expect(state.value).toBe(initialValue)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(false)
   })
 
   it('should onChange well', async () => {
@@ -22,13 +22,13 @@ describe('FieldState', () => {
     state.onChange(value)
 
     expect(state.value).toBe(value)
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
 
     const newValue = '789'
     state.onChange('456')
     state.onChange(newValue)
     expect(state.value).toBe(newValue)
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
 
     const invalidValue = '123456'
     state.onChange(invalidValue)
@@ -42,7 +42,7 @@ describe('FieldState', () => {
     const value = '123'
     state.set(value)
     expect(state.value).toBe(value)
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
 
     // set 不应该使 field 激活
     expect(state.validating).toBe(false)
@@ -56,7 +56,7 @@ describe('FieldState', () => {
     state.validate()
     await delay()
     expect(state.value).toBe(value)
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
   })
 
   it('should reset well', async () => {
@@ -68,13 +68,13 @@ describe('FieldState', () => {
     state.reset()
 
     expect(state.value).toBe(initialValue)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(false)
 
     state.onChange('456')
     state.reset()
 
     expect(state.value).toBe(initialValue)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(false)
   })
 })
 
@@ -155,7 +155,7 @@ describe('FieldState validation', () => {
 
     state.reset()
     expect(state.value).toBe(initialValue)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(false)
     expect(state.validating).toBe(false)
     expect(state.hasError).toBe(false)
     expect(state.error).toBeUndefined()

--- a/src/fieldState.ts
+++ b/src/fieldState.ts
@@ -1,6 +1,5 @@
-import { observable, computed, action, makeObservable, override } from 'mobx'
+import { observable, action, makeObservable, override } from 'mobx'
 import { IState } from './types'
-import { is } from './utils'
 import { ValidatableState } from './state'
 
 /**
@@ -10,22 +9,23 @@ export class FieldState<V> extends ValidatableState<V> implements IState<V> {
 
   @observable.ref value!: V
 
+  @observable touched = false
+
   @action onChange(value: V) {
     this.value = value
     this.activated = true
+    this.touched = true
   }
 
   @action set(value: V) {
     this.value = value
+    this.touched = true
   }
 
   @override override reset() {
     super.reset()
     this.value = this.initialValue
-  }
-
-  @computed get dirty() {
-    return !is(this.value, this.initialValue)
+    this.touched = false
   }
 
   constructor(private initialValue: V) {

--- a/src/formState.spec.ts
+++ b/src/formState.spec.ts
@@ -16,7 +16,7 @@ describe('FormState (mode: object)', () => {
     expect(isObservable(state.$)).toBe(true)
     expect(state.$.foo).toBeInstanceOf(FieldState)
     expect(state.$.bar).toBeInstanceOf(FieldState)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(false)
   })
 
   it('should initialize well with observable fields', () => {
@@ -44,7 +44,7 @@ describe('FormState (mode: object)', () => {
     await delay()
 
     expect(state.value).toEqual(value)
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
   })
 
   it('should set well', async () => {
@@ -59,7 +59,7 @@ describe('FormState (mode: object)', () => {
     expect(state.value).toEqual(value1)
     expect(state.$.foo.value).toBe(value1.foo)
     expect(state.$.bar.value).toBe(value1.bar)
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
 
     state.reset()
 
@@ -68,7 +68,7 @@ describe('FormState (mode: object)', () => {
     expect(state.value).toEqual(value2)
     expect(state.$.foo.value).toBe(value2.foo)
     expect(state.$.bar.value).toBe(value2.bar)
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
 
     state.reset()
 
@@ -77,7 +77,7 @@ describe('FormState (mode: object)', () => {
     expect(state.value).toEqual(value3)
     expect(state.$.foo.value).toBe(value3.foo)
     expect(state.$.bar.value).toBe(value3.bar)
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
 
     state.reset()
 
@@ -85,7 +85,7 @@ describe('FormState (mode: object)', () => {
     expect(state.value).toEqual(initialValue)
     expect(state.$.foo.value).toBe(initialValue.foo)
     expect(state.$.bar.value).toBe(initialValue.bar)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(true)
   })
 
   it('should onChange well', async () => {
@@ -101,7 +101,7 @@ describe('FormState (mode: object)', () => {
     expect(state.value).toEqual(value1)
     expect(state.$.foo.value).toBe(value1.foo)
     expect(state.$.bar.value).toBe(value1.bar)
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
 
     state.reset()
 
@@ -111,7 +111,7 @@ describe('FormState (mode: object)', () => {
     expect(state.value).toEqual(value2)
     expect(state.$.foo.value).toBe(value2.foo)
     expect(state.$.bar.value).toBe(value2.bar)
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
 
     state.reset()
 
@@ -121,7 +121,7 @@ describe('FormState (mode: object)', () => {
     expect(state.value).toEqual(value3)
     expect(state.$.foo.value).toBe(value3.foo)
     expect(state.$.bar.value).toBe(value3.bar)
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
 
     state.reset()
 
@@ -130,7 +130,7 @@ describe('FormState (mode: object)', () => {
     expect(state.value).toEqual(initialValue)
     expect(state.$.foo.value).toBe(initialValue.foo)
     expect(state.$.bar.value).toBe(initialValue.bar)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(true)
   })
 
   it('should reset well', async () => {
@@ -146,7 +146,7 @@ describe('FormState (mode: object)', () => {
     state.reset()
 
     expect(state.value).toEqual(initialValue)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(false)
   })
 })
 
@@ -275,7 +275,7 @@ describe('FormState (mode: object) validation', () => {
 
     state.reset()
     expect(state.value).toEqual(initialValue)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(false)
     expect(state.validating).toBe(false)
     expect(state.hasOwnError).toBe(false)
     expect(state.ownError).toBeUndefined()
@@ -607,7 +607,7 @@ describe('FormState (mode: array)', () => {
     state.$.forEach(field => {
       expect(field).toBeInstanceOf(FieldState)
     })
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(false)
   })
 
   it('should initialize well with correct typing', () => {
@@ -633,7 +633,7 @@ describe('FormState (mode: array)', () => {
     await delay()
 
     expect(state.value).toEqual(value)
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
   })
 
   it('should set well', async () => {
@@ -649,7 +649,7 @@ describe('FormState (mode: array)', () => {
     state.$.forEach((field, i) => {
       expect(field.value).toBe(value1[i])
     })
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
     expect(state.hasError).toBe(false)
 
     state.reset()
@@ -661,7 +661,7 @@ describe('FormState (mode: array)', () => {
     state.$.forEach((field, i) => {
       expect(field.value).toBe(value2[i])
     })
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
     expect(state.hasError).toBe(false)
 
     state.reset()
@@ -674,7 +674,7 @@ describe('FormState (mode: array)', () => {
     state.$.forEach((field, i) => {
       expect(field.value).toBe(value3[i])
     })
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
     expect(state.hasError).toBe(false)
     expect(field2Dispose).toBeCalled()
 
@@ -685,7 +685,7 @@ describe('FormState (mode: array)', () => {
     state.set(value4)
     expect(state.value).toEqual(value4)
     expect(state.$).toHaveLength(value4.length)
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
     expect(state.hasError).toBe(false)
     expect(field1Dispose).toBeCalled()
   })
@@ -704,7 +704,7 @@ describe('FormState (mode: array)', () => {
     state.$.forEach((field, i) => {
       expect(field.value).toBe(value1[i])
     })
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
     expect(state.hasError).toBe(true)
 
     state.reset()
@@ -717,7 +717,7 @@ describe('FormState (mode: array)', () => {
     state.$.forEach((field, i) => {
       expect(field.value).toBe(value2[i])
     })
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
     expect(state.hasError).toBe(true)
 
     state.reset()
@@ -731,7 +731,7 @@ describe('FormState (mode: array)', () => {
     state.$.forEach((field, i) => {
       expect(field.value).toBe(value3[i])
     })
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
     expect(field2Dispose).toBeCalled()
     expect(state.hasError).toBe(false)
 
@@ -743,7 +743,7 @@ describe('FormState (mode: array)', () => {
     await delay()
     expect(state.value).toEqual(value4)
     expect(state.$).toHaveLength(value4.length)
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
     expect(field1Dispose).toBeCalled()
   })
 
@@ -947,7 +947,7 @@ describe('FormState (mode: array)', () => {
     state.reset()
 
     expect(state.value).toEqual(initialValue)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(false)
   })
 
   it('should reset well with fields changed', async () => {
@@ -956,42 +956,42 @@ describe('FormState (mode: array)', () => {
     let disposeFn: () => void
 
     state.remove(-1)
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
 
     disposeFn = state.$[0].dispose = jest.fn(state.$[0].dispose)
     state.reset()
 
     expect(state.value).toEqual(initialValue)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(false)
     expect(disposeFn).toBeCalled()
 
     state.append('789')
     const field = state.$[state.$.length - 1]
     disposeFn = field.dispose = jest.fn(field.dispose)
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
 
     state.reset()
 
     expect(state.value).toEqual(initialValue)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(false)
     expect(disposeFn).toBeCalled()
 
     state.set([])
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
 
     state.reset()
 
     expect(state.value).toEqual(initialValue)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(false)
 
     state.set(['456', '789', '012'])
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
 
     disposeFn = state.$[0].dispose = jest.fn(state.$[2].dispose)
     state.reset()
 
     expect(state.value).toEqual(initialValue)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(false)
     expect(disposeFn).toBeCalled()
   })
 
@@ -1085,7 +1085,7 @@ describe('FormState (mode: array) validation', () => {
 
     state.reset()
     expect(state.value).toEqual(initialValue)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(false)
     expect(state.validating).toBe(false)
     expect(state.hasOwnError).toBe(false)
     expect(state.ownError).toBeUndefined()
@@ -1506,7 +1506,7 @@ describe('nested FormState', () => {
     it('with initial status', () => {
       const sourceConfigState = createSourceConfigState(initialValue)
       expect(sourceConfigState.value).toEqual(initialValue)
-      expect(sourceConfigState.dirty).toBe(false)
+      expect(sourceConfigState.touched).toBe(false)
       sourceConfigState.dispose()
     })
 
@@ -1515,11 +1515,11 @@ describe('nested FormState', () => {
       const value1 = { type: 'bar', addrs: [addr1, addr2] }
       sourceConfigState.set(value1)
       expect(sourceConfigState.value).toEqual(value1)
-      expect(sourceConfigState.dirty).toBe(true)
+      expect(sourceConfigState.touched).toBe(true)
 
       sourceConfigState.reset()
       expect(sourceConfigState.value).toEqual(initialValue)
-      expect(sourceConfigState.dirty).toBe(false)
+      expect(sourceConfigState.touched).toBe(false)
       sourceConfigState.dispose()
     })
 
@@ -1527,11 +1527,11 @@ describe('nested FormState', () => {
       const sourceConfigState = createSourceConfigState(initialValue)
       sourceConfigState.$.addrs.set([])
       expect(sourceConfigState.value).toEqual({ ...initialValue, addrs: [] })
-      expect(sourceConfigState.dirty).toBe(true)
+      expect(sourceConfigState.touched).toBe(true)
 
       sourceConfigState.reset()
       expect(sourceConfigState.value).toEqual(initialValue)
-      expect(sourceConfigState.dirty).toBe(false)
+      expect(sourceConfigState.touched).toBe(false)
       sourceConfigState.dispose()
     })
 
@@ -1539,11 +1539,11 @@ describe('nested FormState', () => {
       const sourceConfigState = createSourceConfigState(initialValue)
       sourceConfigState.$.addrs.set([addr1, addr2, addr3])
       expect(sourceConfigState.value).toEqual({ ...initialValue, addrs: [addr1, addr2, addr3] })
-      expect(sourceConfigState.dirty).toBe(true)
+      expect(sourceConfigState.touched).toBe(true)
 
       sourceConfigState.reset()
       expect(sourceConfigState.value).toEqual(initialValue)
-      expect(sourceConfigState.dirty).toBe(false)
+      expect(sourceConfigState.touched).toBe(false)
       sourceConfigState.dispose()
     })
 
@@ -1554,11 +1554,11 @@ describe('nested FormState', () => {
         ...initialValue,
         addrs: [{ ...addr1, protocols: ['https'] }]
       })
-      expect(sourceConfigState.dirty).toBe(true)
+      expect(sourceConfigState.touched).toBe(true)
 
       sourceConfigState.reset()
       expect(sourceConfigState.value).toEqual(initialValue)
-      expect(sourceConfigState.dirty).toBe(false)
+      expect(sourceConfigState.touched).toBe(false)
       sourceConfigState.dispose()
     })
 
@@ -1569,11 +1569,11 @@ describe('nested FormState', () => {
         ...initialValue,
         addrs: [...initialValue.addrs, addr3]
       })
-      expect(sourceConfigState.dirty).toBe(true)
+      expect(sourceConfigState.touched).toBe(true)
 
       sourceConfigState.reset()
       expect(sourceConfigState.value).toEqual(initialValue)
-      expect(sourceConfigState.dirty).toBe(false)
+      expect(sourceConfigState.touched).toBe(false)
       sourceConfigState.dispose()
     })
 
@@ -1584,11 +1584,11 @@ describe('nested FormState', () => {
         ...initialValue,
         addrs: [{ ...addr1, protocols: ['http', 'https'] }]
       })
-      expect(sourceConfigState.dirty).toBe(true)
+      expect(sourceConfigState.touched).toBe(true)
 
       sourceConfigState.reset()
       expect(sourceConfigState.value).toEqual(initialValue)
-      expect(sourceConfigState.dirty).toBe(false)
+      expect(sourceConfigState.touched).toBe(false)
       sourceConfigState.dispose()
     })
 
@@ -1596,7 +1596,7 @@ describe('nested FormState', () => {
       const sourceConfigState = createSourceConfigState(initialValue)
       sourceConfigState.set(initialValue)
       expect(sourceConfigState.value).toEqual(initialValue)
-      expect(sourceConfigState.dirty).toBe(false)
+      expect(sourceConfigState.touched).toBe(true)
       sourceConfigState.dispose()
     })
   })

--- a/src/formState.ts
+++ b/src/formState.ts
@@ -48,12 +48,12 @@ abstract class AbstractFormState<T, V> extends ValidatableState<V> implements IS
   }
 
   /** If reference of child states has been touched. */
-  @observable protected ownDirty = false
+  @observable protected ownTouched = false
 
-  @computed get dirty() {
+  @computed get touched() {
     return (
-      this.ownDirty
-      || this.childStates.some(state => state.dirty)
+      this.ownTouched
+      || this.childStates.some(state => state.touched)
     )
   }
 
@@ -62,7 +62,7 @@ abstract class AbstractFormState<T, V> extends ValidatableState<V> implements IS
 
   @override override reset() {
     super.reset()
-    this.ownDirty = false
+    this.ownTouched = false
     this.resetChildStates()
   }
 
@@ -204,13 +204,13 @@ export class ArrayFormState<
     this.childStates.splice(fromIndex, num).forEach(state => {
       state.dispose()
     })
-    this.ownDirty = true
+    this.ownTouched = true
   }
 
   private _insert(fromIndex: number, ...childValues: V[]) {
     const states = childValues.map(this.createChildState)
     this.childStates.splice(fromIndex, 0, ...states)
-    this.ownDirty = true
+    this.ownTouched = true
   }
 
   private _set(value: V[], withOnChange = false) {
@@ -281,7 +281,7 @@ export class ArrayFormState<
 
     const [state] = this.childStates.splice(fromIndex, 1)
     this.childStates.splice(toIndex, 0, state)
-    this.ownDirty = true
+    this.ownTouched = true
     this.activated = true
   }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -40,7 +40,7 @@ export abstract class BaseState extends Disposable implements Pick<
 export abstract class ValidatableState<V> extends BaseState implements IState<V> {
 
   abstract value: V
-  abstract dirty: boolean
+  abstract touched: boolean
   abstract onChange(value: V): void
   abstract set(value: V): void
 

--- a/src/transformedState.spec.ts
+++ b/src/transformedState.spec.ts
@@ -67,7 +67,7 @@ describe('TransformedState (for FieldState)', () => {
     const state = createNumState(initialValue)
 
     expect(state.value).toBe(initialValue)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(false)
   })
 
   it('should onChange well', async () => {
@@ -80,14 +80,14 @@ describe('TransformedState (for FieldState)', () => {
     state.onChange(value)
     await delay()
     expect(state.value).toBe(value)
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
 
     const newValue = 100
     state.onChange(50)
     state.onChange(newValue)
     await delay()
     expect(state.value).toBe(newValue)
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
 
     const invalidValue = 200
     state.onChange(invalidValue)
@@ -102,7 +102,7 @@ describe('TransformedState (for FieldState)', () => {
     const value = 123
     state.set(value)
     expect(state.value).toBe(value)
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
 
     // set 不应该使 field 激活
     expect(state.validating).toBe(false)
@@ -116,7 +116,7 @@ describe('TransformedState (for FieldState)', () => {
     state.validate()
     await delay()
     expect(state.value).toBe(value)
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
   })
 
   it('should reset well', async () => {
@@ -128,13 +128,13 @@ describe('TransformedState (for FieldState)', () => {
     state.reset()
 
     expect(state.value).toBe(initialValue)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(false)
 
     state.onChange(456)
     state.reset()
 
     expect(state.value).toBe(initialValue)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(false)
   })
 })
 
@@ -224,7 +224,7 @@ describe('TransformedState (for FieldState) validation', () => {
 
     state.reset()
     expect(state.value).toBe(initialValue)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(false)
     expect(state.validating).toBe(false)
     expect(state.hasError).toBe(false)
     expect(state.error).toBeUndefined()
@@ -444,7 +444,7 @@ describe('TransformedState (for FormState)', () => {
     const state = createNumState(initialValue)
 
     expect(state.value).toBe(initialValue)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(false)
   })
 
   it('should set well', async () => {
@@ -455,13 +455,13 @@ describe('TransformedState (for FormState)', () => {
     expect(state.value).toEqual('qiniu.com:443')
     expect(state.$.$.hostname.value).toBe('qiniu.com')
     expect(state.$.$.port.value).toBe(443)
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
 
     state.set('127.0.0.1:80')
     expect(state.value).toEqual('127.0.0.1:80')
     expect(state.$.$.hostname.value).toBe('127.0.0.1')
     expect(state.$.$.port.value).toBe(80)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(true)
   })
 
   it('should onChange well', async () => {
@@ -472,7 +472,7 @@ describe('TransformedState (for FormState)', () => {
     expect(state.value).toEqual('qiniu.com:443')
     expect(state.$.$.hostname.value).toBe('qiniu.com')
     expect(state.$.$.port.value).toBe(443)
-    expect(state.dirty).toBe(true)
+    expect(state.touched).toBe(true)
 
     state.reset()
 
@@ -481,7 +481,7 @@ describe('TransformedState (for FormState)', () => {
     expect(state.value).toEqual('127.0.0.1:80')
     expect(state.$.$.hostname.value).toBe('127.0.0.1')
     expect(state.$.$.port.value).toBe(80)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(true)
   })
 
   it('should reset well', async () => {
@@ -495,7 +495,7 @@ describe('TransformedState (for FormState)', () => {
     expect(state.value).toEqual('127.0.0.1:80')
     expect(state.$.$.hostname.value).toBe('127.0.0.1')
     expect(state.$.$.port.value).toBe(80)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(false)
 
     state.onChange('qiniu.com:443')
     await delay()
@@ -504,7 +504,7 @@ describe('TransformedState (for FormState)', () => {
     expect(state.value).toEqual('127.0.0.1:80')
     expect(state.$.$.hostname.value).toBe('127.0.0.1')
     expect(state.$.$.port.value).toBe(80)
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(false)
   })
 })
 
@@ -683,7 +683,7 @@ describe('TransformedState (for FormState) validation', () => {
 
     state.reset()
     expect(state.value).toEqual('')
-    expect(state.dirty).toBe(false)
+    expect(state.touched).toBe(false)
     expect(state.validating).toBe(false)
     expect(state.hasError).toBe(false)
     expect(state.error).toBeUndefined()

--- a/src/transformedState.ts
+++ b/src/transformedState.ts
@@ -31,8 +31,8 @@ export class TransformedState<S extends IState<$V>, V, $V = ValueOf<S>> extends 
     return this.$.error
   }
 
-  @computed get dirty() {
-    return this.$.dirty
+  @computed get touched() {
+    return this.$.touched
   }
 
   @computed get activated() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,7 @@ export interface IState<V = unknown> {
   /** Value in the state. */
   value: V
   /** If value has been touched. */
-  dirty: boolean
+  touched: boolean
   /** The error info of validation. */
   error: ValidationError
   /** If the state contains error. */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -71,8 +71,3 @@ export function debounce(fn: () => void, delay: number) {
 export function isArrayLike(value: unknown): value is unknown[] | IObservableArray {
   return Array.isArray(value) || isObservableArray(value)
 }
-
-export function is(value1: any, value2: any) {
-  // TODO: Browser compatibity?
-  return Object.is(value1, value2)
-}


### PR DESCRIPTION
* Renaming: `dirty` -> `touched` for `IState`
* Change behavior of `dirty` / `touched` for `FieldState`

    `onChange` / `set` with initial value will now make `touched` to be `true`. See details in #63 备注.

    ```ts
    state.dirty // false
    state.onChange(state.initialValue)
    state.dirty // true
    ```
* Fix `error` for `DebouncedState`, now it's debounced, too