### PR TITLE
Optimize `validate()` behavior when validation disabled

### DIFF
--- a/src/fieldState.spec.ts
+++ b/src/fieldState.spec.ts
@@ -367,6 +367,17 @@ describe('FieldState validation', () => {
     expect(state.hasError).toBe(false)
     expect(state.error).toBeUndefined()
 
+    runInAction(() => options.disabled = false)
+
+    await delay()
+    expect(state.validating).toBe(false)
+    expect(state.validated).toBe(false)
+    expect(state.hasError).toBe(false)
+    expect(state.error).toBeUndefined()
+
+    runInAction(() => options.disabled = true)
+
+    await delay()
     state.onChange('123')
     await delay()
     state.onChange('')

--- a/src/fieldState.ts
+++ b/src/fieldState.ts
@@ -71,7 +71,7 @@ export default class FieldState<TValue> extends Disposable implements Composible
 
   /**
    * The most recent validation result.
-   * If state is disabled, the result of the last validation is obtained.
+   * If state is disabled and later enabled, the result of the last validation is obtained.
    * If you need to clear the validation result, please use the reset function.
    */
   @computed private get validateResult(): ValidateResult<TValue> {

--- a/src/fieldState.ts
+++ b/src/fieldState.ts
@@ -70,6 +70,17 @@ export default class FieldState<TValue> extends Disposable implements Composible
   }
 
   /**
+   * The most recent validation result.
+   * If state is disabled, the result of the last validation is obtained.
+   * If you need to clear the validation result, please use the reset function.
+   */
+  @computed get validateResult(): ValidateResult<TValue> {
+    return this.hasError
+      ? { hasError: true, error: this.error } as const
+      : { hasError: false, value: this.value } as const
+  }
+
+  /**
    * If the validation has been done.
    * It does not means validation passed.
    */
@@ -152,6 +163,10 @@ export default class FieldState<TValue> extends Disposable implements Composible
    * Fire a validation behavior.
    */
   async validate(): Promise<ValidateResult<TValue>> {
+    if (this.validationDisabled) {
+      return this.validateResult
+    }
+
     const validation = this.validation
 
     action('activate-and-sync-_value-when-validate', () => {
@@ -172,11 +187,7 @@ export default class FieldState<TValue> extends Disposable implements Composible
       { name: 'return-validate-when-not-validating' }
     )
 
-    return (
-      this.hasError
-      ? { hasError: true, error: this.error } as const
-      : { hasError: false, value: this.value } as const
-    )
+    return this.validateResult
   }
 
   /**

--- a/src/fieldState.ts
+++ b/src/fieldState.ts
@@ -74,7 +74,7 @@ export default class FieldState<TValue> extends Disposable implements Composible
    * If state is disabled, the result of the last validation is obtained.
    * If you need to clear the validation result, please use the reset function.
    */
-  @computed get validateResult(): ValidateResult<TValue> {
+  @computed private get validateResult(): ValidateResult<TValue> {
     return this.hasError
       ? { hasError: true, error: this.error } as const
       : { hasError: false, value: this.value } as const

--- a/src/formState.spec.ts
+++ b/src/formState.spec.ts
@@ -473,6 +473,18 @@ describe('FormState (mode: object) validation', () => {
     expect(state.ownError).toBeUndefined()
     expect(state.error).toBeUndefined()
 
+    runInAction(() => options.disabled = false)
+
+    await delay()
+    expect(state.validating).toBe(false)
+    expect(state.validated).toBe(false)
+    expect(state.hasError).toBe(false)
+    expect(state.ownError).toBeUndefined()
+    expect(state.error).toBeUndefined()
+
+    runInAction(() => options.disabled = true)
+
+    await delay()
     state.$.foo.onChange('')
     await state.validate()
     expect(state.hasOwnError).toBe(false)

--- a/src/formState.ts
+++ b/src/formState.ts
@@ -139,7 +139,7 @@ export default class FormState<TFields extends ValidatableFields, TValue = Value
 
   /**
    * The most recent validation result.
-   * If state is disabled, the result of the last validation is obtained.
+   * If state is disabled and later enabled, the result of the last validation is obtained.
    * If you need to clear the validation result, please use the reset function.
    */
   @computed private get validateResult(): ValidateResult<TValue> {

--- a/src/formState.ts
+++ b/src/formState.ts
@@ -142,7 +142,7 @@ export default class FormState<TFields extends ValidatableFields, TValue = Value
    * If state is disabled, the result of the last validation is obtained.
    * If you need to clear the validation result, please use the reset function.
    */
-  @computed get validateResult(): ValidateResult<TValue> {
+  @computed private get validateResult(): ValidateResult<TValue> {
     return this.hasError
       ? { hasError: true, error: this.error } as const
       : { hasError: false, value: this.value } as const

--- a/src/formState.ts
+++ b/src/formState.ts
@@ -138,6 +138,17 @@ export default class FormState<TFields extends ValidatableFields, TValue = Value
   }
 
   /**
+   * The most recent validation result.
+   * If state is disabled, the result of the last validation is obtained.
+   * If you need to clear the validation result, please use the reset function.
+   */
+  @computed get validateResult(): ValidateResult<TValue> {
+    return this.hasError
+      ? { hasError: true, error: this.error } as const
+      : { hasError: false, value: this.value } as const
+  }
+
+  /**
    * If the validation has been done.
    * It does not means validation passed.
    */
@@ -219,6 +230,10 @@ export default class FormState<TFields extends ValidatableFields, TValue = Value
    * Fire a validation behavior.
    */
   async validate(): Promise<ValidateResult<TValue>> {
+    if (this.validationDisabled) {
+      return this.validateResult
+    }
+
     action('activate-when-validate', () => {
       this._activated = true
     })()
@@ -234,11 +249,7 @@ export default class FormState<TFields extends ValidatableFields, TValue = Value
       { name: 'return-validate-when-not-validating' }
     )
 
-    return (
-      this.hasError
-      ? { hasError: true, error: this.error } as const
-      : { hasError: false, value: this.value } as const
-    )
+    return this.validateResult
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,7 +42,6 @@ export interface Validatable<T, TValue = T> {
   validated: boolean
   validationDisabled: boolean
   validate(): Promise<ValidateResult<TValue>>
-  validateResult: ValidateResult<TValue>
   // To see if there are requirements: enableAutoValidation, disableAutoValidation
   // enableAutoValidation: () => void
   // disableAutoValidation: () => void

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,7 +42,7 @@ export interface Validatable<T, TValue = T> {
   validated: boolean
   validationDisabled: boolean
   validate(): Promise<ValidateResult<TValue>>
-
+  validateResult: ValidateResult<TValue>
   // To see if there are requirements: enableAutoValidation, disableAutoValidation
   // enableAutoValidation: () => void
   // disableAutoValidation: () => void


### PR DESCRIPTION
When the state is disabled, the validator should not be executed, and the state validation result (state.validation) should not change.